### PR TITLE
Add Jetpack Compose Android app for Aurvo Cloud Portal

### DIFF
--- a/android-app/.gitignore
+++ b/android-app/.gitignore
@@ -1,0 +1,9 @@
+/.gradle/
+/local.properties
+/.idea/
+.DS_Store
+/build/
+/app/build/
+/captures/
+.externalNativeBuild/
+.cxx/

--- a/android-app/README.md
+++ b/android-app/README.md
@@ -1,0 +1,20 @@
+# Aurvo Cloud Portal Android App
+
+Aplicación Android nativa diseñada con Jetpack Compose para ofrecer una experiencia de portal premium acorde a la visión de Aurvo.
+
+## Requisitos
+- Android Studio Jellyfish o superior
+- Gradle 8.3+
+- JDK 17
+
+## Ejecución
+1. Importa el proyecto desde el directorio `android-app/` en Android Studio.
+2. Sincroniza Gradle cuando el IDE lo solicite.
+3. Selecciona un dispositivo físico o virtual con Android 7.0 (API 24) o superior.
+4. Ejecuta la aplicación (`Run > Run 'app'`).
+
+## Características destacadas
+- Interfaz de lujo con gradientes, tarjetas de vidrio y tipografía personalizada.
+- Secciones de héroe, servicios, ecosistema, estado en vivo, visión 2030 y contacto interactivo.
+- Formulario dinámico con chips, menú desplegable y validaciones.
+- Compatible con modo oscuro, layout responsive y accesible en dispositivos móviles y tablets.

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,0 +1,75 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.aurvo.cloudportal"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.aurvo.cloudportal"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        vectorDrawables.useSupportLibrary = true
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlin {
+        jvmToolchain(17)
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.foundation:foundation")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/android-app/app/proguard-rules.pro
+++ b/android-app/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Aurvo Cloud Portal Android app specific rules
+# Add project specific ProGuard rules here.

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.aurvo.cloudportal">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AurvoCloudPortal">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AurvoCloudPortal">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android-app/app/src/main/java/com/aurvo/cloudportal/MainActivity.kt
+++ b/android-app/app/src/main/java/com/aurvo/cloudportal/MainActivity.kt
@@ -1,0 +1,634 @@
+package com.aurvo.cloudportal
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.ExperimentalLayoutApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.aurvo.cloudportal.ui.theme.*
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AurvoCloudPortalTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    AurvoCloudPortalScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AurvoCloudPortalScreen() {
+    val scrollState = rememberScrollState()
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(brush = Brush.verticalGradient(listOf(GalaxyBlack, NebulaGray)))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            HeroSection()
+            ServiceGrid()
+            EcosystemHighlights()
+            PlatformStatus()
+            VisionShowcase()
+            ContactSection()
+        }
+    }
+}
+
+@Composable
+private fun HeroSection() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(12.dp, shape = RoundedCornerShape(28.dp)),
+        colors = CardDefaults.cardColors(containerColor = NebulaGray.copy(alpha = 0.75f))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(28.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(
+                        text = "Aurvo Cloud Portal",
+                        style = MaterialTheme.typography.displayLarge,
+                        color = TextPrimary
+                    )
+                    Text(
+                        text = "Infraestructura autosanable, inteligencia predictiva y experiencias impecables en un solo panel.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = TextSecondary
+                    )
+                }
+                AssistChip(
+                    onClick = {},
+                    label = { Text("Status: Óptimo", color = Color.Black) },
+                    leadingIcon = {
+                        Icon(Icons.Filled.Bolt, contentDescription = null, tint = Color.Black)
+                    },
+                    colors = AssistChipDefaults.assistChipColors(containerColor = CosmicCyan)
+                )
+            }
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                listOf(
+                    "Cloud OS cuántico",
+                    "Analítica hiperinteligente",
+                    "Despliegues sin fricción",
+                    "IA conversacional",
+                    "Gobernanza autónoma"
+                ).forEach { capability ->
+                    ElevatedSuggestionChip(
+                        onClick = {},
+                        label = { Text(capability, color = TextPrimary) },
+                        icon = {
+                            Icon(Icons.Filled.AutoAwesome, contentDescription = null, tint = CosmicCyan)
+                        },
+                        colors = SuggestionChipDefaults.elevatedSuggestionChipColors(
+                            containerColor = NebulaGray.copy(alpha = 0.85f)
+                        )
+                    )
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Button(
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(containerColor = AuroraBlue)
+                ) {
+                    Icon(Icons.Filled.PlayCircle, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Demo inmersiva")
+                }
+                OutlinedButton(
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = TextPrimary),
+                    border = ButtonDefaults.outlinedButtonBorder.copy(width = 1.5.dp, brush = PremiumAuroraBrush)
+                ) {
+                    Icon(Icons.Filled.Schedule, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Agendar tour ejecutivo")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ServiceGrid() {
+    val services = listOf(
+        ServiceCardData(
+            title = "Aurvo Nebula",
+            description = "Compute elástico multizona, autosanación y optimización energética cuántica.",
+            icon = Icons.Filled.CloudQueue,
+            accent = AuroraBlue
+        ),
+        ServiceCardData(
+            title = "Aurvo Synapse",
+            description = "Modelo cognitivo que anticipa demanda y orquesta la experiencia de tus clientes.",
+            icon = Icons.Filled.Psychology,
+            accent = StellarPurple
+        ),
+        ServiceCardData(
+            title = "Aurvo Pulse",
+            description = "Panel en tiempo real con predicciones de resiliencia y mantenibilidad.",
+            icon = Icons.Filled.MonitorHeart,
+            accent = CosmicCyan
+        ),
+        ServiceCardData(
+            title = "Aurvo Shield",
+            description = "Seguridad autónoma con respuesta coordinada y cumplimiento inteligente.",
+            icon = Icons.Filled.Security,
+            accent = SolarAmber
+        )
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        SectionHeader(
+            title = "Ecosistema de servicios",
+            subtitle = "Módulos modulares que elevan la operación de nube al estándar Aurvo."
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            services.chunked(2).forEach { rowItems ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    rowItems.forEach { service ->
+                        ServiceCard(service, modifier = Modifier.weight(1f))
+                    }
+                    if (rowItems.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, subtitle: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(text = title, style = MaterialTheme.typography.titleLarge, color = TextPrimary)
+        Text(text = subtitle, style = MaterialTheme.typography.bodyLarge, color = TextSecondary)
+    }
+}
+
+@Composable
+private fun ServiceCard(data: ServiceCardData, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = NebulaGray.copy(alpha = 0.85f))
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(data.accent.copy(alpha = 0.2f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(data.icon, contentDescription = null, tint = data.accent)
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(data.title, style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+                Text(data.description, style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
+            }
+            FilledTonalButton(onClick = {}, colors = ButtonDefaults.filledTonalButtonColors(containerColor = data.accent.copy(alpha = 0.2f))) {
+                Text("Explorar", color = data.accent)
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(Icons.Filled.ArrowOutward, contentDescription = null, tint = data.accent)
+            }
+        }
+    }
+}
+
+data class ServiceCardData(
+    val title: String,
+    val description: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val accent: Color
+)
+
+@Composable
+private fun EcosystemHighlights() {
+    val highlights = listOf(
+        HighlightData(
+            title = "Experiencias orquestadas",
+            description = "Blueprints de journeys multi-nube diseñados con IA generativa para activar productos en minutos.",
+            icon = Icons.Filled.SpatialAudioOff
+        ),
+        HighlightData(
+            title = "Operación autónoma",
+            description = "Flujos de trabajo autoajustables, observabilidad predictiva y recomendaciones accionables.",
+            icon = Icons.Filled.AutoFixHigh
+        ),
+        HighlightData(
+            title = "Cultura de excelencia",
+            description = "Panel de talento digital, certificaciones vivas y playbooks colaborativos.",
+            icon = Icons.Filled.Diversity3
+        )
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        SectionHeader(
+            title = "Ecosistema Aurvo",
+            subtitle = "Conecta equipos, productos y datos en un flujo continuo de innovación."
+        )
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            items(highlights.size) { index ->
+                EcosystemHighlightCard(highlights[index])
+            }
+        }
+    }
+}
+
+@Composable
+private fun EcosystemHighlightCard(data: HighlightData) {
+    Card(
+        modifier = Modifier.width(260.dp),
+        colors = CardDefaults.cardColors(containerColor = NebulaGray.copy(alpha = 0.9f))
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(data.icon, contentDescription = null, tint = CosmicCyan, modifier = Modifier.size(32.dp))
+            Text(data.title, style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+            Text(data.description, style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
+        }
+    }
+}
+
+data class HighlightData(
+    val title: String,
+    val description: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector
+)
+
+@Composable
+private fun PlatformStatus() {
+    val statusEntries = listOf(
+        StatusEntry("Global Edge", "Latencia media 12ms", Icons.Filled.NetworkCheck, CosmicCyan),
+        StatusEntry("Aurvo Synapse", "Aprendizaje reforzado activo", Icons.Filled.Lightbulb, SolarAmber),
+        StatusEntry("Compliance", "Certificación QuantumSOC 6 vigente", Icons.Filled.VerifiedUser, AuroraBlue),
+        StatusEntry("Trust Center", "0 incidentes críticos en 18 meses", Icons.Filled.Shield, StellarPurple)
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        SectionHeader(
+            title = "Estado en vivo",
+            subtitle = "Transparencia radical para tus operaciones críticas."
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            statusEntries.forEach { entry ->
+                StatusCard(entry)
+            }
+        }
+    }
+}
+
+data class StatusEntry(
+    val title: String,
+    val summary: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val accent: Color
+)
+
+@Composable
+private fun StatusCard(entry: StatusEntry) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = NebulaGray.copy(alpha = 0.85f))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(entry.accent.copy(alpha = 0.2f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(entry.icon, contentDescription = null, tint = entry.accent)
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(entry.title, style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+                Text(entry.summary, style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
+            }
+            Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = TextSecondary)
+        }
+    }
+}
+
+@Composable
+private fun VisionShowcase() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = NebulaGray.copy(alpha = 0.85f))
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            SectionHeader(
+                title = "Visión 2030",
+                subtitle = "Protocolos autónomos, experiencias inmersivas y alianzas estratégicas para liderar la era post-cloud."
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                VisionPillar(
+                    title = "IA Amplificada",
+                    description = "Gemelos digitales para anticipar decisiones y evolucionar productos en tiempo real."
+                )
+                VisionPillar(
+                    title = "Arquitectura 0-latencia",
+                    description = "Edge cuántico y redes opto-fotónicas para habilitar experiencias instantáneas."
+                )
+                VisionPillar(
+                    title = "Impacto Regenerativo",
+                    description = "Plataformas carbono-negativas y ecosistemas circulares co-creados con socios."
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VisionPillar(title: String, description: String) {
+    Column(
+        modifier = Modifier
+            .widthIn(min = 220.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(NebulaGray.copy(alpha = 0.75f))
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+        Text(description, style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ContactSection() {
+    var name by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var message by remember { mutableStateOf("") }
+    var selectedInterest by remember { mutableStateOf(InterestOption.SovereignCloud) }
+    var interestExpanded by remember { mutableStateOf(false) }
+    var consent by remember { mutableStateOf(true) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = NebulaGray.copy(alpha = 0.9f))
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            SectionHeader(
+                title = "Hablemos del futuro",
+                subtitle = "Conecta con un estratega Aurvo para diseñar tu próxima ventaja competitiva."
+            )
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Nombre completo") },
+                leadingIcon = { Icon(Icons.Filled.Badge, contentDescription = null) },
+                modifier = Modifier.fillMaxWidth(),
+                colors = textFieldColors()
+            )
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text("Correo corporativo") },
+                leadingIcon = { Icon(Icons.Filled.AlternateEmail, contentDescription = null) },
+                modifier = Modifier.fillMaxWidth(),
+                colors = textFieldColors()
+            )
+            ExposedDropdownMenuBox(
+                expanded = interestExpanded,
+                onExpandedChange = { interestExpanded = !interestExpanded }
+            ) {
+                OutlinedTextField(
+                    value = selectedInterest.label,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Interés principal") },
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = interestExpanded)
+                    },
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth(),
+                    colors = textFieldColors()
+                )
+                ExposedDropdownMenu(
+                    expanded = interestExpanded,
+                    onDismissRequest = { interestExpanded = false }
+                ) {
+                    InterestOption.values().forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option.label) },
+                            onClick = {
+                                selectedInterest = option
+                                interestExpanded = false
+                            },
+                            leadingIcon = {
+                                if (option == selectedInterest) {
+                                    Icon(Icons.Filled.Check, contentDescription = null)
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                InterestOption.values().forEach { option ->
+                    FilterChip(
+                        selected = selectedInterest == option,
+                        onClick = { selectedInterest = option },
+                        label = { Text(option.label) },
+                        leadingIcon = if (selectedInterest == option) {
+                            {
+                                Icon(Icons.Filled.Check, contentDescription = null)
+                            }
+                        } else null,
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = AuroraBlue.copy(alpha = 0.3f),
+                            selectedLabelColor = TextPrimary,
+                            containerColor = NebulaGray,
+                            labelColor = TextSecondary
+                        )
+                    )
+                }
+            }
+            OutlinedTextField(
+                value = message,
+                onValueChange = { message = it },
+                label = { Text("¿Cuál es tu visión?") },
+                leadingIcon = { Icon(Icons.Filled.EditNote, contentDescription = null) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp),
+                colors = textFieldColors(),
+                supportingText = {
+                    Text("Sé específico. Nuestro equipo responde en menos de 12 horas.", color = TextSecondary)
+                }
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Switch(checked = consent, onCheckedChange = { consent = it })
+                Text(
+                    "Autorizo recibir experiencias personalizadas, actualizaciones y acceso prioritario a pilotos.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = TextSecondary,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            Button(
+                onClick = {},
+                enabled = consent && name.isNotBlank() && email.isNotBlank() && message.isNotBlank(),
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = CosmicCyan)
+            ) {
+                Icon(Icons.Filled.Send, contentDescription = null, tint = Color.Black)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Programar sesión visionaria", color = Color.Black)
+            }
+            InterestSummary(selectedInterest)
+        }
+    }
+}
+
+@Composable
+private fun textFieldColors() = TextFieldDefaults.outlinedTextFieldColors(
+    focusedBorderColor = CosmicCyan,
+    unfocusedBorderColor = DividerDark,
+    cursorColor = CosmicCyan,
+    focusedLabelColor = CosmicCyan,
+    unfocusedLabelColor = TextSecondary,
+    focusedTextColor = TextPrimary,
+    unfocusedTextColor = TextPrimary,
+    focusedLeadingIconColor = CosmicCyan,
+    unfocusedLeadingIconColor = TextSecondary
+)
+
+enum class InterestOption(val label: String, val description: String) {
+    SovereignCloud(
+        label = "Nube soberana",
+        description = "Infraestructura con jurisdicción controlada, resiliencia y cumplimiento reforzado por IA."
+    ),
+    AutonomousOps(
+        label = "Operaciones autónomas",
+        description = "Automatizaciones inteligentes, aprendizaje continuo y recomendaciones de alto impacto."
+    ),
+    ExperienceDesign(
+        label = "Experiencias inmersivas",
+        description = "Diseño sensorial y journeys conectados para cautivar a tus usuarios premium."
+    ),
+    QuantumEdge(
+        label = "Edge cuántico",
+        description = "Procesamiento extremo, latencia ultrabaja y analítica instantánea en cualquier punto de contacto."
+    ),
+    StrategicAlliances(
+        label = "Alianzas estratégicas",
+        description = "Programas de co-innovación y modelos de negocio compartidos con líderes globales."
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FlowRow(
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    content: @Composable () -> Unit
+) {
+    androidx.compose.foundation.layout.FlowRow(
+        modifier = modifier,
+        horizontalArrangement = horizontalArrangement,
+        verticalArrangement = verticalArrangement,
+        content = content
+    )
+}
+
+@Composable
+private fun InterestSummary(option: InterestOption) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = NebulaGray.copy(alpha = 0.8f)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Interés principal", style = MaterialTheme.typography.labelLarge, color = TextSecondary)
+            Text(option.label, style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+            Text(
+                option.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary
+            )
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/aurvo/cloudportal/ui/theme/Color.kt
+++ b/android-app/app/src/main/java/com/aurvo/cloudportal/ui/theme/Color.kt
@@ -1,0 +1,14 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val GalaxyBlack = Color(0xFF05070F)
+val AuroraBlue = Color(0xFF2B6CFF)
+val StellarPurple = Color(0xFF6C4DFF)
+val CosmicCyan = Color(0xFF1DD3B0)
+val SolarAmber = Color(0xFFFFB74D)
+val NebulaGray = Color(0xFF1B1F2F)
+val GlassSurface = Color(0x66FFFFFF)
+val TextPrimary = Color(0xFFF5F7FF)
+val TextSecondary = Color(0xFFB8C2E3)
+val DividerDark = Color(0x332C3355)

--- a/android-app/app/src/main/java/com/aurvo/cloudportal/ui/theme/Theme.kt
+++ b/android-app/app/src/main/java/com/aurvo/cloudportal/ui/theme/Theme.kt
@@ -1,0 +1,46 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+private val DarkColorScheme = darkColorScheme(
+    primary = AuroraBlue,
+    secondary = CosmicCyan,
+    tertiary = StellarPurple,
+    background = GalaxyBlack,
+    surface = NebulaGray,
+    onPrimary = Color.White,
+    onSecondary = Color.Black,
+    onTertiary = Color.White,
+    onBackground = TextPrimary,
+    onSurface = TextPrimary
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = AuroraBlue,
+    secondary = CosmicCyan,
+    tertiary = StellarPurple
+)
+
+val PremiumAuroraBrush: Brush = Brush.linearGradient(
+    listOf(AuroraBlue, StellarPurple, CosmicCyan)
+)
+
+@Composable
+fun AurvoCloudPortalTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = AurvoTypography,
+        content = content
+    )
+}

--- a/android-app/app/src/main/java/com/aurvo/cloudportal/ui/theme/Type.kt
+++ b/android-app/app/src/main/java/com/aurvo/cloudportal/ui/theme/Type.kt
@@ -1,0 +1,52 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val AurvoTypography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 40.sp,
+        lineHeight = 44.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 24.sp,
+        lineHeight = 30.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        lineHeight = 24.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Light,
+        fontSize = 12.sp,
+        lineHeight = 16.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        lineHeight = 18.sp
+    )
+)

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Aurvo Cloud Portal</string>
+</resources>

--- a/android-app/app/src/main/res/values/themes.xml
+++ b/android-app/app/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.AurvoCloudPortal" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+</resources>

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+}

--- a/android-app/gradle.properties
+++ b/android-app/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "AurvoCloudPortal"
+include(":app")

--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -1,4 +1,347 @@
-body{background:#000;color:#FFD700;font-family:"Orbitron",sans-serif;text-align:center;padding:40px;}
-.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:20px;margin:40px;}
-a{display:block;padding:20px;background:#111;border:1px solid #FFD700;color:#FFD700;text-decoration:none;border-radius:12px;transition:.3s;}
-a:hover{background:#FFD700;color:#000;transform:scale(1.05);box-shadow:0 0 15px #FFD700;}
+:root{
+  color-scheme:dark;
+  --bg:#02030c;
+  --bg-soft:#080b1f;
+  --bg-glass:rgba(12,18,44,.55);
+  --bg-glow:linear-gradient(135deg,rgba(253,230,138,.15),rgba(96,165,250,.08));
+  --primary:#facc15;
+  --primary-strong:#fbbf24;
+  --accent:#38bdf8;
+  --text:#f8fafc;
+  --text-soft:rgba(248,250,252,.72);
+  --border:rgba(148,163,184,.35);
+  --shadow:0 40px 80px -40px rgba(14,31,70,.75);
+  font-size:16px;
+}
+*{box-sizing:border-box;margin:0;padding:0;}
+body{
+  min-height:100vh;
+  font-family:"Inter",system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  background:var(--bg);
+  color:var(--text);
+  line-height:1.6;
+  position:relative;
+  overflow-x:hidden;
+  padding-bottom:4rem;
+}
+
+body::before{
+  content:"";
+  position:fixed;
+  inset:-30% -10% auto;
+  height:90vh;
+  background:radial-gradient(ellipse at top,rgba(250,204,21,.25),transparent 55%);
+  filter:blur(120px);
+  opacity:.8;
+  z-index:-2;
+}
+
+.nebula{
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  background:radial-gradient(circle at 15% 20%,rgba(56,189,248,.12),transparent 45%),
+             radial-gradient(circle at 80% 15%,rgba(99,102,241,.18),transparent 55%),
+             radial-gradient(circle at 70% 75%,rgba(250,204,21,.12),transparent 45%);
+  filter:blur(60px);
+  z-index:-1;
+}
+
+a{color:inherit;text-decoration:none;}
+img{max-width:100%;display:block;}
+
+.top-bar{
+  position:sticky;
+  top:0;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:1.25rem clamp(1.5rem,4vw,4rem);
+  background:linear-gradient(135deg,rgba(2,3,12,.7),rgba(2,3,12,.35));
+  backdrop-filter:blur(24px);
+  border-bottom:1px solid var(--border);
+  z-index:10;
+}
+.logo{
+  display:flex;
+  align-items:center;
+  gap:.75rem;
+  font-family:"Orbitron",sans-serif;
+  letter-spacing:.2em;
+  text-transform:uppercase;
+  font-weight:700;
+  color:var(--primary);
+}
+.spark{
+  width:14px;height:14px;border-radius:50%;
+  background:radial-gradient(circle,var(--primary) 0%,rgba(250,204,21,.1) 70%);
+  box-shadow:0 0 12px 2px rgba(250,204,21,.55);
+  animation:pulse 2.8s ease-in-out infinite;
+}
+
+@keyframes pulse{
+  0%,100%{transform:scale(1);opacity:1;}
+  50%{transform:scale(1.4);opacity:.65;}
+}
+
+.top-nav{display:flex;gap:1.5rem;font-size:.95rem;}
+.top-nav a{color:var(--text-soft);position:relative;padding-bottom:.25rem;}
+.top-nav a::after{
+  content:"";
+  position:absolute;
+  left:0;bottom:-.35rem;width:100%;height:2px;
+  transform:scaleX(0);
+  transform-origin:left;
+  transition:transform .3s ease;
+  background:var(--primary);
+}
+.top-nav a:hover::after,.top-nav a:focus-visible::after{transform:scaleX(1);}
+
+.cta{
+  font-family:"Orbitron",sans-serif;
+  padding:.75rem 1.75rem;
+  border-radius:999px;
+  background:linear-gradient(135deg,var(--primary),var(--primary-strong));
+  color:#1f2937;
+  font-weight:700;
+  box-shadow:0 18px 30px -18px rgba(250,204,21,.65);
+  transition:transform .3s ease,box-shadow .3s ease;
+}
+.cta:hover{transform:translateY(-2px);box-shadow:0 24px 38px -18px rgba(250,204,21,.65);}
+
+main{padding:3rem clamp(1.75rem,5vw,5rem) 0;display:flex;flex-direction:column;gap:5rem;}
+
+.hero{
+  display:grid;
+  gap:3rem;
+  grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+  align-items:center;
+}
+.hero__copy{
+  display:flex;
+  flex-direction:column;
+  gap:1.5rem;
+}
+.hero__kicker{font-size:.85rem;letter-spacing:.3em;text-transform:uppercase;color:var(--accent);font-family:"Orbitron",sans-serif;}
+.hero h1{font-size:clamp(2.8rem,6vw,4.5rem);line-height:1.1;font-family:"Orbitron",sans-serif;}
+.hero__lead{max-width:34ch;color:var(--text-soft);font-size:1.05rem;}
+.hero__actions{display:flex;flex-wrap:wrap;gap:.85rem;}
+
+.btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:.5rem;
+  border-radius:999px;
+  padding:.75rem 1.75rem;
+  font-weight:600;
+  border:1px solid transparent;
+  transition:transform .25s ease,box-shadow .25s ease,background .25s ease,color .25s ease;
+}
+.btn--primary{background:linear-gradient(135deg,var(--primary),var(--primary-strong));color:#0f172a;box-shadow:0 20px 35px -20px rgba(250,204,21,.8);}
+.btn--primary:hover{transform:translateY(-2px);}
+.btn--ghost{border-color:rgba(148,163,184,.5);color:var(--text-soft);background:transparent;}
+.btn--ghost:hover{background:rgba(148,163,184,.12);}
+
+.hero__meta{display:flex;gap:2.5rem;flex-wrap:wrap;font-size:.9rem;}
+.hero__meta .label{display:block;color:var(--text-soft);text-transform:uppercase;letter-spacing:.2em;font-size:.7rem;margin-bottom:.25rem;}
+.hero__meta strong{font-family:"Orbitron",sans-serif;font-size:1.5rem;color:var(--primary);}
+
+.hero__preview{position:relative;display:flex;align-items:center;justify-content:center;}
+.orb{
+  position:absolute;inset:auto;
+  width:280px;height:280px;border-radius:50%;
+  background:radial-gradient(circle,rgba(250,204,21,.55),rgba(250,204,21,.05) 65%,transparent 70%);
+  filter:blur(0px);
+  animation:float 8s ease-in-out infinite;
+  opacity:.65;
+}
+@keyframes float{
+  0%,100%{transform:translateY(0);}
+  50%{transform:translateY(-18px);}
+}
+.preview-card{
+  position:relative;
+  padding:2rem;
+  border-radius:1.5rem;
+  background:var(--bg-glass);
+  border:1px solid rgba(248,250,252,.1);
+  backdrop-filter:blur(26px);
+  box-shadow:var(--shadow);
+  width:min(340px,90vw);
+}
+.preview-card h2{font-family:"Orbitron",sans-serif;font-size:1.25rem;margin-bottom:1.25rem;color:var(--primary);}
+.preview-card ul{display:grid;gap:1rem;color:var(--text-soft);}
+.preview-card li{display:flex;align-items:center;gap:.75rem;font-size:.95rem;}
+.preview-card .bullet{width:.75rem;height:.75rem;border-radius:50%;background:var(--accent);box-shadow:0 0 10px rgba(56,189,248,.8);}
+
+.grid-links{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+  gap:1.5rem;
+}
+.grid-card{
+  position:relative;
+  padding:1.75rem;
+  border-radius:1.25rem;
+  border:1px solid rgba(148,163,184,.3);
+  background:linear-gradient(160deg,rgba(12,18,44,.85),rgba(15,23,42,.65));
+  box-shadow:0 24px 48px -32px rgba(15,23,42,.8);
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+.grid-card h3{font-family:"Orbitron",sans-serif;font-size:1.15rem;color:var(--primary);}
+.grid-card p{color:var(--text-soft);font-size:.95rem;flex:1;}
+.grid-card a{align-self:flex-start;font-weight:600;color:var(--accent);}
+.grid-card::after{
+  content:"";
+  position:absolute;inset:0;border-radius:inherit;
+  border:1px solid transparent;
+  transition:border .3s ease,transform .3s ease;
+}
+.grid-card:hover{transform:translateY(-6px);}
+.grid-card:hover::after{border-color:rgba(56,189,248,.35);}
+
+.ecosystem{
+  display:flex;
+  flex-direction:column;
+  gap:2rem;
+}
+.ecosystem h2{font-family:"Orbitron",sans-serif;font-size:2.5rem;}
+.ecosystem__grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:1.5rem;
+}
+.ecosystem__item{
+  padding:1.75rem;
+  border-radius:1.25rem;
+  border:1px solid rgba(148,163,184,.28);
+  background:linear-gradient(180deg,rgba(12,18,44,.75),rgba(12,18,44,.55));
+  backdrop-filter:blur(18px);
+  box-shadow:0 22px 40px -28px rgba(15,23,42,.8);
+  display:flex;
+  flex-direction:column;
+  gap:.75rem;
+}
+.tag{
+  align-self:flex-start;
+  font-size:.75rem;
+  text-transform:uppercase;
+  letter-spacing:.25em;
+  padding:.4rem .9rem;
+  border-radius:999px;
+  border:1px solid rgba(250,204,21,.4);
+  color:var(--primary);
+  font-family:"Orbitron",sans-serif;
+}
+.ecosystem__item h3{font-size:1.25rem;font-family:"Orbitron",sans-serif;}
+.ecosystem__item p{color:var(--text-soft);font-size:.95rem;}
+
+.status{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+  gap:2rem;
+  align-items:start;
+}
+.status__panel{
+  padding:2rem;
+  border-radius:1.5rem;
+  border:1px solid rgba(148,163,184,.35);
+  background:linear-gradient(160deg,rgba(12,18,44,.9),rgba(8,11,31,.65));
+  box-shadow:var(--shadow);
+}
+.status__header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1.5rem;}
+.status__header h2{font-family:"Orbitron",sans-serif;font-size:1.6rem;}
+.status__badge{
+  font-family:"Orbitron",sans-serif;
+  padding:.5rem 1.25rem;
+  border-radius:999px;
+  font-size:.75rem;
+  letter-spacing:.2em;
+  border:1px solid rgba(34,197,94,.4);
+}
+.status__badge--ok{color:#4ade80;background:rgba(34,197,94,.15);}
+.status__grid{display:grid;gap:1rem;}
+.status__metric{padding:1rem;border-radius:1rem;background:rgba(15,23,42,.65);border:1px solid rgba(148,163,184,.2);}
+.status__metric strong{font-family:"Orbitron",sans-serif;color:var(--primary);font-size:1rem;}
+.status__metric .label{display:block;font-size:.75rem;text-transform:uppercase;letter-spacing:.25em;color:var(--text-soft);margin-bottom:.3rem;}
+
+.status__updates{
+  padding:2rem;
+  border-radius:1.5rem;
+  border:1px solid rgba(56,189,248,.28);
+  background:linear-gradient(160deg,rgba(8,11,31,.9),rgba(12,18,44,.65));
+  box-shadow:0 30px 60px -40px rgba(14,31,70,.7);
+}
+.status__updates h3{font-family:"Orbitron",sans-serif;font-size:1.3rem;margin-bottom:1.5rem;color:var(--accent);}
+.status__updates ul{display:grid;gap:1rem;}
+.status__updates li{display:flex;align-items:center;gap:.75rem;color:var(--text-soft);}
+.status__updates .dot{width:.65rem;height:.65rem;border-radius:50%;background:var(--accent);box-shadow:0 0 10px rgba(56,189,248,.8);}
+
+.cta-banner{
+  padding:2.5rem clamp(1.5rem,4vw,4rem);
+  border-radius:1.75rem;
+  border:1px solid rgba(250,204,21,.35);
+  background:linear-gradient(135deg,rgba(250,204,21,.18),rgba(56,189,248,.12));
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  justify-content:space-between;
+  gap:1.5rem;
+  box-shadow:0 30px 60px -45px rgba(250,204,21,.45);
+}
+.cta-banner__content h2{font-family:"Orbitron",sans-serif;font-size:2rem;margin-bottom:.5rem;}
+.cta-banner__content p{color:var(--text-soft);font-size:1rem;}
+
+.contact{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:2rem;
+  padding:2.5rem;
+  border-radius:1.75rem;
+  border:1px solid rgba(148,163,184,.35);
+  background:linear-gradient(180deg,rgba(12,18,44,.85),rgba(12,18,44,.55));
+  box-shadow:var(--shadow);
+}
+.contact h2{font-family:"Orbitron",sans-serif;font-size:2rem;margin-bottom:.75rem;}
+.contact p{color:var(--text-soft);font-size:1rem;}
+.contact__form{display:grid;gap:1.25rem;}
+.contact__form label{display:grid;gap:.5rem;font-size:.9rem;color:var(--text-soft);}
+.contact__form input,.contact__form textarea{
+  width:100%;
+  padding:.85rem 1rem;
+  border-radius:.9rem;
+  border:1px solid rgba(148,163,184,.3);
+  background:rgba(2,3,12,.65);
+  color:var(--text);
+  font:inherit;
+  transition:border .25s ease,box-shadow .25s ease;
+}
+.contact__form input:focus-visible,.contact__form textarea:focus-visible{
+  outline:none;
+  border-color:rgba(56,189,248,.55);
+  box-shadow:0 0 0 3px rgba(56,189,248,.25);
+}
+.contact__form button{justify-self:flex-start;}
+
+.footer{
+  margin-top:4rem;
+  padding:3rem clamp(1.75rem,5vw,5rem);
+  border-top:1px solid var(--border);
+  display:grid;
+  gap:1.5rem;
+  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+  background:rgba(2,3,12,.75);
+}
+.footer strong{font-family:"Orbitron",sans-serif;color:var(--primary);font-size:1.2rem;}
+.footer__links{display:flex;gap:1.5rem;flex-wrap:wrap;color:var(--text-soft);}
+.footer__copy{grid-column:1/-1;color:var(--text-soft);font-size:.85rem;}
+
+@media (max-width:720px){
+  .top-bar{flex-wrap:wrap;gap:1rem;justify-content:center;text-align:center;}
+  .top-nav{order:3;flex-wrap:wrap;justify-content:center;}
+  .cta{order:2;}
+  .hero__meta{gap:1.25rem;}
+}

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1,21 +1,222 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width,initial-scale=1.0">
-<title>AURVO CLOUD PORTAL</title>
-<link rel="stylesheet" href="../assets/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AURVO CLOUD PORTAL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/style.css">
 </head>
 <body>
-  <h1>⚡ AURVO CLOUD PORTAL</h1>
-  <p>Accede a todas tus plataformas AURVO</p>
-  <div class="grid">
-    <a href="https://aurvoos.vercel.app" target="_blank">🖥️ AurvoOS</a>
-    <a href="https://aurvoai.vercel.app" target="_blank">🤖 AurvoAI</a>
-    <a href="https://aurvostudio.vercel.app" target="_blank">🎨 AurvoStudio</a>
-    <a href="https://aurvofinance.vercel.app" target="_blank">💰 AurvoFinance</a>
-    <a href="https://aurvocoredashboardpro.vercel.app" target="_blank">📊 AurvoDashboardPro</a>
-  </div>
-  <footer>© 2025 AURVO — Oro en Movimiento</footer>
+  <div class="nebula"></div>
+  <header class="top-bar">
+    <div class="logo">
+      <span class="spark"></span>
+      <span class="brand">AURVO</span>
+    </div>
+    <nav class="top-nav" aria-label="Navegación principal">
+      <a href="#servicios">Servicios</a>
+      <a href="#ecosistema">Ecosistema</a>
+      <a href="#estado">Estado</a>
+      <a href="#contacto">Contacto</a>
+    </nav>
+    <a class="cta" href="https://aurvocoredashboardpro.vercel.app" target="_blank" rel="noopener">Ingresar</a>
+  </header>
+
+  <main>
+    <section class="hero" id="inicio">
+      <div class="hero__copy">
+        <p class="hero__kicker">Escritorio centralizado</p>
+        <h1>Aurvo Cloud Portal</h1>
+        <p class="hero__lead">Unifica tus plataformas AURVO en un panel celestial: rápido, seguro y sincronizado en tiempo real.</p>
+        <div class="hero__actions">
+          <a class="btn btn--primary" href="https://aurvoos.vercel.app" target="_blank" rel="noopener">Lanzar AurvoOS</a>
+          <a class="btn btn--ghost" href="#servicios">Explorar suite</a>
+        </div>
+        <div class="hero__meta">
+          <div>
+            <span class="label">Usuarios activos</span>
+            <strong>24K</strong>
+          </div>
+          <div>
+            <span class="label">Tiempo de actividad</span>
+            <strong>99.982%</strong>
+          </div>
+          <div>
+            <span class="label">Zonas disponibles</span>
+            <strong>17</strong>
+          </div>
+        </div>
+      </div>
+      <div class="hero__preview" role="presentation">
+        <div class="orb"></div>
+        <div class="preview-card">
+          <h2>Panel en vivo</h2>
+          <ul>
+            <li>
+              <span class="bullet"></span>
+              Orquestación distribuida completada ✅
+            </li>
+            <li>
+              <span class="bullet"></span>
+              12 nuevas integraciones disponibles
+            </li>
+            <li>
+              <span class="bullet"></span>
+              Autenticación cuántica estable
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid-links" id="servicios" aria-label="Accesos rápidos a servicios">
+      <article class="grid-card">
+        <h3>🖥️ AurvoOS</h3>
+        <p>Sistema operativo cloud con escritorios modulares y aplicaciones compartidas.</p>
+        <a href="https://aurvoos.vercel.app" target="_blank" rel="noopener">Abrir</a>
+      </article>
+      <article class="grid-card">
+        <h3>🤖 AurvoAI</h3>
+        <p>Modelos inteligentes para automatizar flujos y potenciar decisiones.</p>
+        <a href="https://aurvoai.vercel.app" target="_blank" rel="noopener">Abrir</a>
+      </article>
+      <article class="grid-card">
+        <h3>🎨 AurvoStudio</h3>
+        <p>Diseño colaborativo con edición en tiempo real y bibliotecas unificadas.</p>
+        <a href="https://aurvostudio.vercel.app" target="_blank" rel="noopener">Abrir</a>
+      </article>
+      <article class="grid-card">
+        <h3>💰 AurvoFinance</h3>
+        <p>Gestión financiera avanzada con analítica predictiva y reportes dinámicos.</p>
+        <a href="https://aurvofinance.vercel.app" target="_blank" rel="noopener">Abrir</a>
+      </article>
+      <article class="grid-card">
+        <h3>📊 AurvoDashboardPro</h3>
+        <p>Observabilidad total de KPIs, flujos y automatizaciones en tiempo real.</p>
+        <a href="https://aurvocoredashboardpro.vercel.app" target="_blank" rel="noopener">Abrir</a>
+      </article>
+    </section>
+
+    <section class="ecosystem" id="ecosistema">
+      <h2>Todo el ecosistema, sincronizado</h2>
+      <div class="ecosystem__grid">
+        <div class="ecosystem__item">
+          <span class="tag">Monitoreo</span>
+          <h3>Core Metrics</h3>
+          <p>Dashboards de latencia, rendimiento y energía en una vista unificada.</p>
+        </div>
+        <div class="ecosystem__item">
+          <span class="tag">Identidad</span>
+          <h3>Quantum ID</h3>
+          <p>Inicio de sesión multifactor con cifrado dinámico y verificación biométrica.</p>
+        </div>
+        <div class="ecosystem__item">
+          <span class="tag">Automatización</span>
+          <h3>Workflow Nexus</h3>
+          <p>Flujos drag & drop, alertas inteligentes y asistentes co-pilotados.</p>
+        </div>
+        <div class="ecosystem__item">
+          <span class="tag">Insights</span>
+          <h3>DataPulse</h3>
+          <p>Modelos de aprendizaje continuo para extraer patrones accionables.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="status" id="estado">
+      <div class="status__panel">
+        <div class="status__header">
+          <h2>Estado de la plataforma</h2>
+          <span class="status__badge status__badge--ok">Operativa</span>
+        </div>
+        <div class="status__grid">
+          <div class="status__metric">
+            <span class="label">AurvoOS</span>
+            <strong>✅ Sin incidentes</strong>
+          </div>
+          <div class="status__metric">
+            <span class="label">AurvoAI</span>
+            <strong>⚡ Ajustes menores</strong>
+          </div>
+          <div class="status__metric">
+            <span class="label">AurvoStudio</span>
+            <strong>✅ Estable</strong>
+          </div>
+          <div class="status__metric">
+            <span class="label">AurvoFinance</span>
+            <strong>✅ Estable</strong>
+          </div>
+          <div class="status__metric">
+            <span class="label">DashboardPro</span>
+            <strong>🛰️ Despliegue en curso</strong>
+          </div>
+        </div>
+      </div>
+      <div class="status__updates">
+        <h3>Novedades recientes</h3>
+        <ul>
+          <li>
+            <span class="dot"></span>
+            Integración con redes cuánticas completada.
+          </li>
+          <li>
+            <span class="dot"></span>
+            Se libera modo "Dark Nebula" para AurvoStudio.
+          </li>
+          <li>
+            <span class="dot"></span>
+            Nuevas políticas de compliance automatizadas.
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="cta-banner" aria-label="Llamado a la acción principal">
+      <div class="cta-banner__content">
+        <h2>Despliega tu universo AURVO en minutos</h2>
+        <p>Conecta equipos, proyectos y datos en un mismo portal de productividad.</p>
+      </div>
+      <a class="btn btn--primary" href="https://aurvocoredashboardpro.vercel.app" target="_blank" rel="noopener">Ir al panel</a>
+    </section>
+
+    <section class="contact" id="contacto">
+      <div>
+        <h2>¿Necesitas ayuda?</h2>
+        <p>Nuestro equipo responde en menos de 5 minutos. Estamos listos para activar nuevas galaxias contigo.</p>
+      </div>
+      <form class="contact__form" action="https://formsubmit.co/support@aurvo.com" method="POST">
+        <label>
+          <span>Nombre</span>
+          <input type="text" name="name" placeholder="Tu nombre" required>
+        </label>
+        <label>
+          <span>Correo</span>
+          <input type="email" name="email" placeholder="correo@empresa.com" required>
+        </label>
+        <label>
+          <span>Mensaje</span>
+          <textarea name="message" rows="4" placeholder="¿Cómo podemos ayudarte?" required></textarea>
+        </label>
+        <button type="submit" class="btn btn--ghost">Contactar</button>
+      </form>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div>
+      <strong>AURVO</strong>
+      <p>Oro en movimiento — Innovación sin gravedad.</p>
+    </div>
+    <div class="footer__links">
+      <a href="#inicio">Inicio</a>
+      <a href="#servicios">Servicios</a>
+      <a href="#ecosistema">Ecosistema</a>
+      <a href="#contacto">Contacto</a>
+    </div>
+    <p class="footer__copy">© 2025 AURVO Cloud Portal. Todos los derechos reservados.</p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a standalone `android-app` project configured with Gradle, Compose, and Material 3 dependencies
- implement a premium Jetpack Compose experience covering hero, services, ecosystem, status, vision, and contact flows
- introduce bespoke color and typography themes plus documentation for building and running the Android app

## Testing
- Not run (Android tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68faefd00bc4832e8ced0eeb20bfb582