### PR TITLE
Add native Android app for Aurvo Cloud Portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+android/.gradle/
+android/app/build/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ NEXTAUTH_SECRET="tu_clave_secreta"
 AURVO_API_KEY="tu_api_key_hoc"
 VERCEL_PROJECT_ID="tu_project_id"
 
+📱 **Aplicación Android nativa**
+
+La carpeta [`android/`](android/) contiene una versión optimizada para dispositivos móviles del portal, construida con Kotlin y Jetpack Compose.
+
+```bash
+cd android
+gradle :app:assembleDebug
+```
+
+> Si utilizas Android Studio, el IDE configurará el Gradle Wrapper automáticamente al abrir el proyecto.
+
+El APK resultante quedará en `android/app/build/outputs/apk/debug/`. También puedes abrir la carpeta en Android Studio para emular o publicar la aplicación.
+
 
 ---
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,73 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.aurvo.cloudportal"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.aurvo.cloudportal"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.2")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+
+    testImplementation("junit:junit:4.13.2")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# No custom rules required for now.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="AURVO Cloud Portal"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AurvoCloudPortal">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AurvoCloudPortal">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/aurvo/cloudportal/MainActivity.kt
+++ b/android/app/src/main/java/com/aurvo/cloudportal/MainActivity.kt
@@ -1,0 +1,541 @@
+package com.aurvo.cloudportal
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowOutward
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.aurvo.cloudportal.ui.theme.AurvoCloudPortalTheme
+import com.aurvo.cloudportal.ui.theme.GalacticBackground
+import com.aurvo.cloudportal.ui.theme.HeroGradient
+import com.aurvo.cloudportal.ui.theme.orbitron
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AurvoCloudPortalTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    PortalScreen()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun PortalScreen() {
+    val scrollState = rememberScrollState()
+
+    Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(GalacticBackground)
+                .padding(padding)
+        ) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .alpha(0.5f)
+                    .background(HeroGradient)
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(32.dp)
+            ) {
+                HeroSection()
+                QuickAccessSection()
+                EcosystemSection()
+                StatusSection()
+                CallToActionSection()
+                ContactSection()
+                FooterSection()
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroSection() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Escritorio centralizado",
+            style = MaterialTheme.typography.labelLarge.copy(
+                fontFamily = orbitron,
+                letterSpacing = 6.sp,
+                color = Color(0xFF38BDF8)
+            )
+        )
+        Text(
+            text = "Aurvo Cloud Portal",
+            style = MaterialTheme.typography.displaySmall.copy(
+                fontFamily = orbitron,
+                lineHeight = 42.sp
+            )
+        )
+        Text(
+            text = "Unifica tus plataformas AURVO en un panel celestial: rápido, seguro y sincronizado en tiempo real.",
+            style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
+        )
+        PrimaryActionRow(
+            primary = "Lanzar AurvoOS",
+            secondary = "Explorar suite"
+        )
+        MetricsRow(
+            metrics = listOf(
+                "Usuarios activos" to "24K",
+                "Tiempo de actividad" to "99.982%",
+                "Zonas disponibles" to "17"
+            )
+        )
+        PreviewCard()
+    }
+}
+
+@Composable
+private fun PrimaryActionRow(primary: String, secondary: String) {
+    androidx.compose.foundation.layout.Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        ActionButton(text = primary, elevated = true)
+        ActionButton(text = secondary, elevated = false)
+    }
+}
+
+@Composable
+private fun ActionButton(text: String, elevated: Boolean) {
+    if (elevated) {
+        androidx.compose.material3.Button(
+            onClick = { },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFFFACC15),
+                contentColor = Color(0xFF0F172A)
+            ),
+            elevation = ButtonDefaults.buttonElevation(defaultElevation = 6.dp),
+            modifier = Modifier.shadow(12.dp, shape = MaterialTheme.shapes.large)
+        ) {
+            Text(text = text, style = MaterialTheme.typography.labelLarge)
+        }
+    } else {
+        androidx.compose.material3.OutlinedButton(
+            onClick = { },
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.4f)),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+            ),
+            modifier = Modifier.shadow(0.dp)
+        ) {
+            Text(text = text, style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}
+
+@Composable
+private fun MetricsRow(metrics: List<Pair<String, String>>) {
+    androidx.compose.foundation.layout.Row(
+        horizontalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        metrics.forEach { (label, value) ->
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = label.uppercase(),
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontFamily = orbitron,
+                        letterSpacing = 4.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.headlineSmall.copy(
+                        fontFamily = orbitron,
+                        color = Color(0xFFFACC15)
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewCard() {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.extraLarge),
+        tonalElevation = 12.dp,
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "Panel en vivo",
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontFamily = orbitron,
+                    color = Color(0xFFFACC15)
+                )
+            )
+            listOf(
+                "Orquestación distribuida completada ✅",
+                "12 nuevas integraciones disponibles",
+                "Autenticación cuántica estable"
+            ).forEach { item ->
+                androidx.compose.foundation.layout.Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .clip(MaterialTheme.shapes.small)
+                            .background(Color(0xFF38BDF8))
+                    )
+                    Text(text = item, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickAccessSection() {
+    SectionTitle(title = "Servicios", subtitle = "Accesos rápidos a la suite")
+    val cards = listOf(
+        Triple("🖥️ AurvoOS", "Sistema operativo cloud con escritorios modulares y aplicaciones compartidas.", "Abrir"),
+        Triple("🤖 AurvoAI", "Modelos inteligentes para automatizar flujos y potenciar decisiones.", "Abrir"),
+        Triple("🎨 AurvoStudio", "Diseño colaborativo con edición en tiempo real y bibliotecas unificadas.", "Abrir"),
+        Triple("💰 AurvoFinance", "Gestión financiera avanzada con analítica predictiva y reportes dinámicos.", "Abrir"),
+        Triple("📊 AurvoDashboardPro", "Observabilidad total de KPIs, flujos y automatizaciones en tiempo real.", "Abrir")
+    )
+
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(200.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(vertical = 12.dp)
+    ) {
+        items(cards) { (title, description, action) ->
+            Surface(
+                tonalElevation = 6.dp,
+                modifier = Modifier.clip(MaterialTheme.shapes.extraLarge)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(title, style = MaterialTheme.typography.titleMedium.copy(fontFamily = orbitron, color = Color(0xFFFACC15)))
+                    Text(description, style = MaterialTheme.typography.bodyMedium)
+                    SecondaryLink(action)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(title: String, subtitle: String? = null) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(title, style = MaterialTheme.typography.headlineMedium.copy(fontFamily = orbitron))
+        subtitle?.let {
+            Text(it, style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
+        }
+    }
+}
+
+@Composable
+private fun SecondaryLink(label: String) {
+    androidx.compose.foundation.layout.Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(label, style = MaterialTheme.typography.labelLarge.copy(color = Color(0xFF38BDF8)))
+        Icon(
+            painter = rememberVectorPainter(Icons.Default.ArrowOutward),
+            contentDescription = null,
+            tint = Color(0xFF38BDF8)
+        )
+    }
+}
+
+@Composable
+private fun EcosystemSection() {
+    SectionTitle("Todo el ecosistema, sincronizado")
+    val pillars = listOf(
+        Triple("Monitoreo", "Core Metrics", "Dashboards de latencia, rendimiento y energía en una vista unificada."),
+        Triple("Identidad", "Quantum ID", "Inicio de sesión multifactor con cifrado dinámico y verificación biométrica."),
+        Triple("Automatización", "Workflow Nexus", "Flujos drag & drop, alertas inteligentes y asistentes co-pilotados."),
+        Triple("Insights", "DataPulse", "Modelos de aprendizaje continuo para extraer patrones accionables.")
+    )
+
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(220.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(vertical = 12.dp)
+    ) {
+        items(pillars) { (tag, name, copy) ->
+            Surface(
+                tonalElevation = 8.dp,
+                modifier = Modifier.clip(MaterialTheme.shapes.extraLarge)
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        tag.uppercase(),
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            fontFamily = orbitron,
+                            letterSpacing = 4.sp,
+                            color = Color(0xFFFACC15)
+                        )
+                    )
+                    Text(name, style = MaterialTheme.typography.titleLarge.copy(fontFamily = orbitron))
+                    Text(copy, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusSection() {
+    SectionTitle("Estado de la plataforma")
+    val services = listOf(
+        "AurvoOS" to "✅ Sin incidentes",
+        "AurvoAI" to "⚡ Ajustes menores",
+        "AurvoStudio" to "✅ Estable",
+        "AurvoFinance" to "✅ Estable",
+        "DashboardPro" to "🛰️ Despliegue en curso"
+    )
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        tonalElevation = 8.dp,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Operativa",
+                style = MaterialTheme.typography.labelLarge.copy(
+                    fontFamily = orbitron,
+                    color = Color(0xFF4ADE80)
+                )
+            )
+            services.chunked(2).forEach { rowItems ->
+                androidx.compose.foundation.layout.Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    rowItems.forEach { (label, value) ->
+                        StatusMetric(label, value, Modifier.weight(1f))
+                    }
+                    if (rowItems.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = "Novedades recientes",
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontFamily = orbitron,
+                        color = Color(0xFF38BDF8)
+                    )
+                )
+                listOf(
+                    "Integración con redes cuánticas completada.",
+                    "Se libera modo \"Dark Nebula\" para AurvoStudio.",
+                    "Nuevas políticas de compliance automatizadas."
+                ).forEach { update ->
+                    Text(update, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusMetric(label: String, value: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        tonalElevation = 6.dp,
+        shape = MaterialTheme.shapes.large
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = label.uppercase(),
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontFamily = orbitron,
+                    letterSpacing = 3.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            )
+            Text(value, style = MaterialTheme.typography.bodyLarge.copy(fontFamily = orbitron, color = Color(0xFFFACC15)))
+        }
+    }
+}
+
+@Composable
+private fun CallToActionSection() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        tonalElevation = 10.dp,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        androidx.compose.foundation.layout.Row(
+            modifier = Modifier.padding(24.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Despliega tu universo AURVO en minutos", style = MaterialTheme.typography.titleLarge.copy(fontFamily = orbitron))
+                Text(
+                    "Conecta equipos, proyectos y datos en un mismo portal de productividad.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+            ActionButton(text = "Ir al panel", elevated = true)
+        }
+    }
+}
+
+@Composable
+private fun ContactSection() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        tonalElevation = 8.dp,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text("¿Necesitas ayuda?", style = MaterialTheme.typography.titleLarge.copy(fontFamily = orbitron))
+            Text(
+                "Nuestro equipo responde en menos de 5 minutos. Estamos listos para activar nuevas galaxias contigo.",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Surface(
+                tonalElevation = 4.dp,
+                shape = MaterialTheme.shapes.large,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    ContactField("Nombre")
+                    ContactField("Correo")
+                    ContactField("Mensaje", height = 120.dp)
+                    ActionButton("Contactar", elevated = false)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContactField(label: String, height: Dp = 52.dp) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(label, style = MaterialTheme.typography.labelLarge.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 2.dp,
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(height)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Text(
+                    text = when (label) {
+                        "Nombre" -> "Tu nombre"
+                        "Correo" -> "correo@empresa.com"
+                        else -> "¿Cómo podemos ayudarte?"
+                    },
+                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FooterSection() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            "AURVO",
+            style = MaterialTheme.typography.titleLarge.copy(fontFamily = orbitron, color = Color(0xFFFACC15))
+        )
+        Text(
+            "Oro en movimiento — Innovación sin gravedad.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            "© 2025 AURVO Cloud Portal. Todos los derechos reservados.",
+            style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
+        )
+    }
+}

--- a/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Color.kt
@@ -1,0 +1,10 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val MidnightBlue = Color(0xFF02030C)
+val NebulaOverlay = Color(0x330C122C)
+val SolarGold = Color(0xFFFACC15)
+val AuroraCyan = Color(0xFF38BDF8)
+val Slate = Color(0xFF94A3B8)
+val StarWhite = Color(0xFFF8FAFC)

--- a/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Shape.kt
+++ b/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Shape.kt
@@ -1,0 +1,12 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val aurvoShapes = Shapes(
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(24.dp),
+    extraLarge = RoundedCornerShape(32.dp)
+)

--- a/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Theme.kt
@@ -1,0 +1,55 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+val DarkColorPalette = darkColorScheme(
+    primary = SolarGold,
+    secondary = AuroraCyan,
+    background = MidnightBlue,
+    surface = Color(0xFF0F172A),
+    surfaceVariant = NebulaOverlay,
+    onSurface = StarWhite,
+    onSurfaceVariant = Slate
+)
+
+val LightColorPalette = lightColorScheme(
+    primary = SolarGold,
+    secondary = AuroraCyan,
+    background = StarWhite,
+    surface = Color(0xFFF1F5F9),
+    surfaceVariant = Color(0xFFE2E8F0),
+    onSurface = Color(0xFF0F172A),
+    onSurfaceVariant = Color(0xFF475569)
+)
+
+val GalacticBackground: Brush
+    get() = Brush.radialGradient(
+        colors = listOf(Color(0x330C4A6E), Color.Transparent),
+        radius = 900f
+    )
+
+val HeroGradient: Brush
+    get() = Brush.linearGradient(
+        colors = listOf(Color(0x33FDE68A), Color(0x1038BDF8))
+    )
+
+@Composable
+fun AurvoCloudPortalTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) DarkColorPalette else LightColorPalette
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = aurvoTypography,
+        shapes = aurvoShapes,
+        content = content
+    )
+}

--- a/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/aurvo/cloudportal/ui/theme/Type.kt
@@ -1,0 +1,62 @@
+package com.aurvo.cloudportal.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val orbitron: FontFamily = FontFamily.SansSerif
+
+val aurvoTypography = Typography(
+    displaySmall = TextStyle(
+        fontFamily = orbitron,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 36.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = orbitron,
+        fontWeight = FontWeight.Bold,
+        fontSize = 24.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 22.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 18.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 13.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp
+    )
+)

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FACC15"
+        android:pathData="M54,12c23.196,0 42,18.804 42,42s-18.804,42 -42,42 -42,-18.804 -42,-42 18.804,-42 42,-42zm0,12c-16.569,0 -30,13.431 -30,30s13.431,30 30,30 30,-13.431 30,-30 -13.431,-30 -30,-30z"/>
+    <path
+        android:fillColor="#38BDF8"
+        android:pathData="M54,30c13.255,0 24,10.745 24,24 0,3.314 -2.686,6 -6,6 -3.314,0 -6,-2.686 -6,-6 0,-6.627 -5.373,-12 -12,-12 -6.627,0 -12,5.373 -12,12 0,3.314 -2.686,6 -6,6 -3.314,0 -6,-2.686 -6,-6 0,-13.255 10.745,-24 24,-24z"/>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,3 @@
+<resources>
+    <style name="Theme.AurvoCloudPortal" parent="Theme.Material3.DayNight.NoActionBar" />
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="md_theme_primary">#FACC15</color>
+    <color name="md_theme_onPrimary">#0F172A</color>
+</resources>

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#02030C</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">AURVO Cloud Portal</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.AurvoCloudPortal" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" />
+    <include domain="database" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="sharedpref" />
+        <include domain="database" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="sharedpref" />
+        <include domain="database" />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.5.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "AurvoCloudPortalAndroid"
+include(":app")


### PR DESCRIPTION
## Summary
- add a standalone Android project that recreates the Aurvo Cloud Portal experience with Jetpack Compose
- define Material theme utilities, resources, and manifest/configuration for the native build
- document Android build instructions and ignore local Gradle outputs

## Testing
- gradle tasks *(fails: plugin com.android.application:8.5.0 could not be resolved in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd18669344832ebbcff4838baab20c